### PR TITLE
Support for modifications to word document metadata

### DIFF
--- a/Openize.OpenXML-SDK.csproj
+++ b/Openize.OpenXML-SDK.csproj
@@ -6,9 +6,9 @@
 	  <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	  <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 	  <Description>A .NET library that simplifies working with OpenXML documents. Create, read, and manipulate Wordprocessing documents (Docx), Excel spreadsheets (Xlsx), and PowerPoint presentations (Pptx) effortlessly with Openize.OpenXML SDK. Licensed under MIT.</Description>
-	  <ReleaseVersion>25.3.2</ReleaseVersion>
+	  <ReleaseVersion>25.4.1</ReleaseVersion>
 	  <SynchReleaseVersion>false</SynchReleaseVersion>
-	  <PackageVersion>25.3.2</PackageVersion>
+	  <PackageVersion>25.4.1</PackageVersion>
 	  <Authors>Openize Pty Ltd</Authors>
 	  <Copyright>2024-2025</Copyright>
 	  <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/Openize.OpenXML-SDK.csproj
+++ b/Openize.OpenXML-SDK.csproj
@@ -6,9 +6,9 @@
 	  <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	  <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 	  <Description>A .NET library that simplifies working with OpenXML documents. Create, read, and manipulate Wordprocessing documents (Docx), Excel spreadsheets (Xlsx), and PowerPoint presentations (Pptx) effortlessly with Openize.OpenXML SDK. Licensed under MIT.</Description>
-	  <ReleaseVersion>25.1.0</ReleaseVersion>
+	  <ReleaseVersion>25.3.2</ReleaseVersion>
 	  <SynchReleaseVersion>false</SynchReleaseVersion>
-	  <PackageVersion>25.1.0</PackageVersion>
+	  <PackageVersion>25.3.2</PackageVersion>
 	  <Authors>Openize Pty Ltd</Authors>
 	  <Copyright>2024-2025</Copyright>
 	  <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
@@ -21,6 +21,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DocumentationFile>bin\Debug\netcoreapp3.1\Openize.OpenXMLSDK.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <None Remove="DocumentFormat.OpenXml" />
     

--- a/Word/OpenizeWord.cs
+++ b/Word/OpenizeWord.cs
@@ -267,6 +267,7 @@ namespace Openize.Words
         public void SetDocumentProperties(DocumentProperties documentProperties)
         {
             _documentProperties = documentProperties;
+            if(!_isNew) OWD.OoxmlDocData.CreateInstance().UpdateProperties(this);
         }
         /// <summary>
         /// Updates an existing element in the structure.


### PR DESCRIPTION
closes issue #15 

Provides support for modifying/creating metadata for an existing word document.

## Usage Code Example

```csharp
            var document = new Openize.Words.Document("word.docx");
            var oldProps = document.GetDocumentProperties();
            var props = new Openize.Words.DocumentProperties();

            // Helper to print and update
            void UpdateProperty<T>(string name, T oldValue, T newValue, Action<T> setValue)
            {
                Console.WriteLine($"Old {name} : {oldValue}");
                setValue(newValue);
                Console.WriteLine($"New {name} : {newValue}");
            }

            // Update metadata
            UpdateProperty("Title", oldProps.Title, "Updated Title", val => props.Title = val);
            UpdateProperty("Subject", oldProps.Subject, "Updated Subject", val => props.Subject = val);
            UpdateProperty("Description", oldProps.Description, "Updated Description", val => props.Description = val);
            UpdateProperty("Creator", oldProps.Creator, "Updated Creator", val => props.Creator = val);
            UpdateProperty("Keywords", oldProps.Keywords, "Updated.Keyword", val => props.Keywords = val);
            UpdateProperty("LastModifiedBy", oldProps.LastModifiedBy, "Updated.Openize.OpenXML-SDK", val => props.LastModifiedBy = val);
            UpdateProperty("Revision", oldProps.Revision, "Version.Revised", val => props.Revision = val);
            UpdateProperty("Created", oldProps.Created, oldProps.Created, val => props.Created = val);

            var currentTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ");
            UpdateProperty("Modified", oldProps.Modified, currentTime, val => props.Modified = val);

            document.SetDocumentProperties(props);
            document.Save("word2.docx"); 
```